### PR TITLE
fix zsh java classpath error

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   ```
 
   ```
-  java -cp dist/*:lib/* aamtool.ReactionDecoder -Q SMI -q "CC(O)CC(=O)OC(C)CC(O)=O.O[H]>>[H]OC(=O)CC(C)O.CC(O)CC(O)=O" -g -j  AAM -f TEXT
+  java -cp "dist/*:lib/*" aamtool.ReactionDecoder -Q SMI -q "CC(O)CC(=O)OC(C)CC(O)=O.O[H]>>[H]OC(=O)CC(C)O.CC(O)CC(O)=O" -g -j  AAM -f TEXT
   ```
 
 ####Annotate Reaction using SMILES

--- a/README.txt
+++ b/README.txt
@@ -16,7 +16,7 @@ Annotate Reaction using SMILES
 
 or 
 
-java -cp dist/*:lib/* aamtool.ReactionDecoder -Q SMI -q "CC(O)CC(=O)OC(C)CC(O)=O.O[H]>>[H]OC(=O)CC(C)O.CC(O)CC(O)=O" -g -j AAM -f TEXT
+java -cp "dist/*:lib/*" aamtool.ReactionDecoder -Q SMI -q "CC(O)CC(=O)OC(C)CC(O)=O.O[H]>>[H]OC(=O)CC(C)O.CC(O)CC(O)=O" -g -j AAM -f TEXT
 
 Annotate Reaction using SMILES
 


### PR DESCRIPTION
```
java -cp dist/*:lib/* aamtool.ReactionDecoder -Q SMI -q "CC(O)CC(=O)OC(C)CC(O)=O.O[H]>>[H]OC(=O)CC(C)O.CC(O)CC(O)=O" -g -j  AAM -f TEXT
```

zsh: no matches found: dist/_:lib/_

see: http://stackoverflow.com/a/10230446/2714931
