### PR TITLE
Update to CDK 2.7.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,8 +111,21 @@
         <dependency>
             <groupId>org.openscience.cdk</groupId>
             <artifactId>cdk-bundle</artifactId>
-            <version>2.4-SNAPSHOT</version>
+            <version>2.7.1</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>31.0.1-jre</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-math3</artifactId>
+            <version>3.6.1</version>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/commons-cli/commons-cli -->
         <dependency>
             <groupId>commons-cli</groupId>


### PR DESCRIPTION
We need to include Guava and Math3 since CDK no longer depends on these.

All tests passing OK.